### PR TITLE
Only run rubocop on files that belong to this package

### DIFF
--- a/scripts/Dockerfile_test
+++ b/scripts/Dockerfile_test
@@ -5,4 +5,4 @@ COPY . datadog-lambda-ruby
 WORKDIR /datadog-lambda-ruby
 RUN gem install bundler
 RUN bundle install
-RUN rubocop
+RUN rubocop lib/ test/ datadog-lambda.gemspec


### PR DESCRIPTION
Rubocop running in docker was linting all package dependencies, instead of just the files in this repo. This was breaking the run_tests.sh script, and breaking the deployment process.
