### PR TITLE
Change metric timestamps from seconds to milliseconds

### DIFF
--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -54,7 +54,7 @@ module Datadog
       tags.each do |tag|
         tag_list.push("#{tag[0]}:#{tag[1]}")
       end
-      time_ms = (time.to_f * 1000).to_i
+      time_ms = (time.to_f).to_i
       metric = { e: time_ms, m: name, t: tag_list, v: value }.to_json
       puts metric
     end

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -54,7 +54,7 @@ module Datadog
       tags.each do |tag|
         tag_list.push("#{tag[0]}:#{tag[1]}")
       end
-      time_ms = (time.to_f).to_i
+      time_ms = time.to_f.to_i
       metric = { e: time_ms, m: name, t: tag_list, v: value }.to_json
       puts metric
     end

--- a/lib/datadog/lambda/version.rb
+++ b/lib/datadog/lambda/version.rb
@@ -12,7 +12,7 @@ module Datadog
   module Lambda
     module VERSION
       MAJOR = 0
-      MINOR = 2
+      MINOR = 3
       PATCH = 0
       PRE = nil
 

--- a/test/datadog/lambda.spec.rb
+++ b/test/datadog/lambda.spec.rb
@@ -47,8 +47,9 @@ describe Datadog::Lambda do
   context 'metric' do
     it 'prints a custom metric' do
       now = Time.utc(2008, 7, 8, 9, 10)
+
       # rubocop:disable Metrics/LineLength
-      output = '{"e":1215508200000,"m":"m1","t":["dd_lambda_layer:datadog-ruby25","t.a:val","t.b:v2"],"v":100}'
+      output = '{"e":1215508200,"m":"m1","t":["dd_lambda_layer:datadog-ruby25","t.a:val","t.b:v2"],"v":100}'
       # rubocop:enable Metrics/LineLength
       expect(Time).to receive(:now).and_return(now)
       expect do
@@ -58,7 +59,7 @@ describe Datadog::Lambda do
     it 'prints a custom metric with a custom timestamp' do
       now = Time.utc(2008, 7, 8, 9, 10)
       # rubocop:disable Metrics/LineLength
-      output = '{"e":1215508200000,"m":"m1","t":["dd_lambda_layer:datadog-ruby25","t.a:val","t.b:v2"],"v":100}'
+      output = '{"e":1215508200,"m":"m1","t":["dd_lambda_layer:datadog-ruby25","t.a:val","t.b:v2"],"v":100}'
       # rubocop:enable Metrics/LineLength
       expect do
         Datadog::Lambda.metric('m1', 100, time: now, "t.a": 'val', "t.b": 'v2')


### PR DESCRIPTION
### What does this PR do?

Changes metric timestamps to use seconds instead of milliseconds.
