### PR TITLE
Bump patch number

### DIFF
--- a/lib/datadog/lambda/version.rb
+++ b/lib/datadog/lambda/version.rb
@@ -13,7 +13,7 @@ module Datadog
     module VERSION
       MAJOR = 0
       MINOR = 3
-      PATCH = 0
+      PATCH = 1
       PRE = nil
 
       STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')


### PR DESCRIPTION
### What does this PR do?

Made a mistake while deploying to ruby gems. Need to bump the patch version.