### PR TITLE
Use segment id instead of parent id when injecting into http requests

### DIFF
--- a/lib/datadog/lambda/trace/context.rb
+++ b/lib/datadog/lambda/trace/context.rb
@@ -47,7 +47,7 @@ module Datadog
 
       def current_trace_context(trace_context)
         entity = XRay.recorder.current_entity
-        parent_id = entity.instance_variable_get('@parent_id')
+        parent_id = entity.id
         {
           trace_id: trace_context[:trace_id],
           parent_id: convert_to_apm_parent_id(parent_id),
@@ -57,7 +57,7 @@ module Datadog
 
       def read_trace_context_from_xray
         segment = XRay.recorder.current_entity
-        parent_id = segment.instance_variable_get('@parent_id')
+        parent_id = segment.id
         mode = segment.sampled ? SAMPLE_MODE_USER_KEEP : SAMPLE_MODE_USER_REJECT
         {
           trace_id: convert_to_apm_trace_id(segment.trace_id),

--- a/lib/datadog/lambda/trace/patch_http.rb
+++ b/lib/datadog/lambda/trace/patch_http.rb
@@ -42,8 +42,9 @@ module Datadog
           req[Datadog::Trace::DD_TRACE_ID_HEADER.to_sym] = context[:trace_id]
           logger.debug("added context #{context} to request")
         rescue StandardError => e
-          logger.error(
-            "couldn't add tracing context #{context} to request #{e}"
+          trace = e.backtrace.join("\n ")
+          logger.debug(
+            "couldn't add tracing context #{context} to request #{e}:\n#{trace}"
           )
         end
         super(req, body, &block)

--- a/lib/datadog/lambda/version.rb
+++ b/lib/datadog/lambda/version.rb
@@ -12,8 +12,8 @@ module Datadog
   module Lambda
     module VERSION
       MAJOR = 0
-      MINOR = 3
-      PATCH = 1
+      MINOR = 4
+      PATCH = 0
       PRE = nil
 
       STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')

--- a/test/datadog/lambda/trace/context.spec.rb
+++ b/test/datadog/lambda/trace/context.spec.rb
@@ -3,6 +3,7 @@
 # rubocop:disable Metrics/BlockLength
 
 require 'datadog/lambda/trace/context'
+require 'datadog/lambda/trace/xray_lambda'
 require 'datadog/lambda/trace/constants'
 require 'aws-xray-sdk'
 
@@ -135,9 +136,9 @@ describe Datadog::Trace do
 
   context 'read_trace_context_from_xray' do
     it 'reads the parent id and trace id from X-Ray' do
-      segment = XRay::Segment.new(
+      segment = Datadog::Trace::FacadeSegment.new(
         trace_id: '1-5ce31dc2-ffffffff390ce44db5e03875',
-        parent_id: '0b11cc4230d3e09e'
+        id: '0b11cc4230d3e09e'
       )
       allow(XRay.recorder).to receive(:current_entity).and_return(segment)
       res = Datadog::Trace.read_trace_context_from_xray


### PR DESCRIPTION
### What does this PR do?

Previously, we were incorrectly using the current x-ray segments parent id when injecting trace context into http requests. This PR fixes that.
