### PR TITLE
[SLS-318] Add Ruby layer enhanced metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ You can set the following environment variables via the AWS CLI or Serverless Fr
 
 How much logging datadog-lambda-layer-rb should do. Set this to "debug" for extensive logs.
 
+### DD_ENHANCED_METRICS
+
+If you set the value of this variable to "true" then the Lambda layer will increment a Lambda integration metric called `aws.lambda.enhanced.invocations` with each invocation and `aws.lambda.enhanced.errors` if the invocation results in an error. These metrics are tagged with the function name, region, account, runtime, memorysize, and `cold_start:true|false`.``:w
+
 ## Usage
 
 Datadog needs to be able to read headers from the incoming Lambda event.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ functions:
           path: hello
           method: get
     layers:
-      - arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Rube2-5:1
+      - arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby2-5:1
 ```
 
 ## Environment Variables

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -84,8 +84,18 @@ module Datadog
     end
 
     def self.record_enhanced(metric_name, context)
+      return false unless do_enhanced_metrics?
+
       etags = gen_enhanced_tags(context)
       metric("aws.lambda.enhanced.#{metric_name}", 1, etags)
+      true
+    end
+
+    def self.do_enhanced_metrics?
+      dd_enhanced_metrics = ENV['DD_ENHANCED_METRICS']
+      return false if dd_enhanced_metrics.nil?
+
+      dd_enhanced_metrics.downcase == 'true'
     end
   end
 end

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -77,6 +77,8 @@ module Datadog
         cold_start: @is_cold_start,
         runtime: "Ruby #{RUBY_VERSION}"
       }
+    rescue StandardError => _e
+      {}
     end
 
     # Format and add tags to enhanced metrics

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -38,10 +38,10 @@ module Datadog
         raise e
       ensure
         @listener.on_end
+        # rubocop:disable Style/GlobalVars
+        $IS_COLD_START = false
+        # rubocop:enable Style/GlobalVars
       end
-      # rubocop:disable Style/GlobalVars
-      $IS_COLD_START = false
-      # rubocop:enable Style/GlobalVars
       res
     end
 

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -77,7 +77,9 @@ module Datadog
         cold_start: @is_cold_start,
         runtime: "Ruby #{RUBY_VERSION}"
       }
-    rescue StandardError => _e
+    rescue StandardError => e
+      Datadog::Utils.logger.error 'Unable to parse Lambda context' \
+      "#{context}: #{e}"
       {}
     end
 

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -85,7 +85,7 @@ module Datadog
 
     def self.record_enhanced(metric_name, context)
       etags = gen_enhanced_tags(context)
-      metric(metric_name, 1, etags)
+      metric("aws.lambda.enhanced.#{metric_name}", 1, etags)
     end
   end
 end

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -69,6 +69,9 @@ module Datadog
       puts metric
     end
 
+    # Generate tags for enhanced metrics
+    # @param context [Object] https://docs.aws.amazon.com/lambda/latest/dg/ruby-context.html
+    # @return [hash] a hash of the enhanced metrics tags
     def self.gen_enhanced_tags(context)
       arn_parts = context.invoked_function_arn.split(':')
       {
@@ -83,6 +86,15 @@ module Datadog
       }
     end
 
+    # Format and add tags to enhanced metrics
+    # This method wraps the metric method, checking the DD_ENHANCED_METRICS
+    # environment variable, adding 'aws.lambda.enhanced' to the metric name,
+    # and adding the enhanced metric tags to the enhanced metrics.
+    # @param metric_name [String] basic name of the metric
+    # @param context [Object] AWS Ruby Lambda Context
+    # @return [boolean] false if the metric was not added for some reason,
+    #   true otherwise (for ease of testing)
+
     def self.record_enhanced(metric_name, context)
       return false unless do_enhanced_metrics?
 
@@ -91,6 +103,9 @@ module Datadog
       true
     end
 
+    # Check the DD_ENHANCED_METRICS environment variable
+    # @reurn [boolean] true if this lambda should have
+    # enhanced metrics
     def self.do_enhanced_metrics?
       dd_enhanced_metrics = ENV['DD_ENHANCED_METRICS']
       return false if dd_enhanced_metrics.nil?

--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -14,14 +14,11 @@ require 'datadog/lambda/trace/patch_http'
 require 'json'
 require 'time'
 
-# rubocop:disable Style/GlobalVars
-$IS_COLD_START = true
-# rubocop:enable Style/GlobalVars
-
 module Datadog
   # Instruments AWS Lambda functions with Datadog distributed tracing and
   # custom metrics
   module Lambda
+    @is_cold_start = true
     # Wrap the body of a lambda invocation
     # @param event [Object] event sent to lambda
     # @param context [Object] lambda context
@@ -38,9 +35,7 @@ module Datadog
         raise e
       ensure
         @listener.on_end
-        # rubocop:disable Style/GlobalVars
-        $IS_COLD_START = false
-        # rubocop:enable Style/GlobalVars
+        @is_cold_start = false
       end
       res
     end
@@ -79,9 +74,7 @@ module Datadog
         region: arn_parts[3],
         account_id: arn_parts[4],
         memorysize: context.memory_limit_in_mb,
-        # rubocop:disable Style/GlobalVars
-        cold_start: $IS_COLD_START,
-        # rubocop:enable Style/GlobalVars
+        cold_start: @is_cold_start,
         runtime: "Ruby #{RUBY_VERSION}"
       }
     end

--- a/test/datadog/lambda.spec.rb
+++ b/test/datadog/lambda.spec.rb
@@ -15,7 +15,7 @@ describe Datadog::Lambda do
   context 'with a handler that raises an error' do
     subject { Datadog::Lambda.wrap(event, context) { raise 'Error' } }
     let(:event) { '1' }
-    let(:context) { ctx }
+    let(:context) { '2' }
 
     it 'should raise an error if the block raises an error' do
       expect { subject }.to raise_error
@@ -29,7 +29,7 @@ describe Datadog::Lambda do
   context 'with a succesful handler' do
     subject { Datadog::Lambda.wrap(event, context) { { result: 100 } } }
     let(:event) { '1' }
-    let(:context) { ctx }
+    let(:context) { '2' }
 
     it 'should return the same value as returned by the block' do
       expect(subject[:result]).to be 100

--- a/test/datadog/lambda.spec.rb
+++ b/test/datadog/lambda.spec.rb
@@ -89,6 +89,34 @@ describe Datadog::Lambda do
       # rubocop:enable Metrics/LineLength
     end
   end
+  context 'enhanced metrics' do
+    it 'correctly reads the DD_ENHANCED_METRICS env var' do
+      allow(ENV).to receive(:[]).with('DD_ENHANCED_METRICS').and_return('true')
+      expect(Datadog::Lambda.do_enhanced_metrics?).to eq(true)
+    end
+    it 'correctly reads the DD_ENHANCED_METRICS env var regardless of case' do
+      allow(ENV).to receive(:[]).with('DD_ENHANCED_METRICS').and_return('True')
+      expect(Datadog::Lambda.do_enhanced_metrics?).to eq(true)
+    end
+    it 'correctly reads false DD_ENHANCED_METRICS as false' do
+      allow(ENV).to receive(:[]).with('DD_ENHANCED_METRICS').and_return('false')
+      expect(Datadog::Lambda.do_enhanced_metrics?).to eq(false)
+    end
+    it 'correctly reads lack of DD_ENHANCED_METRICS as false' do
+      allow(ENV).to receive(:[]).with('DD_ENHANCED_METRICS').and_return('false')
+      expect(Datadog::Lambda.do_enhanced_metrics?).to eq(false)
+    end
+  end
+  context 'enhanced metrics' do
+    it 'does not submit enhanced metrics if DD_ENHANCED_METRICS is false' do
+      allow(ENV).to receive(:[]).with('DD_ENHANCED_METRICS').and_return('false')
+      expect(Datadog::Lambda.record_enhanced('foo', ctx)).to eq(false)
+    end
+    it 'submits enhanced metrics if DD_ENHANCED_METRICS is true' do
+      allow(ENV).to receive(:[]).with('DD_ENHANCED_METRICS').and_return('true')
+      expect(Datadog::Lambda.record_enhanced('foo', ctx)).to eq(true)
+    end
+  end
 end
 
 # rubocop:enable Metrics/BlockLength

--- a/test/datadog/lambda.spec.rb
+++ b/test/datadog/lambda.spec.rb
@@ -12,15 +12,6 @@ describe Datadog::Lambda do
       expect(Datadog::Lambda.gen_enhanced_tags(ctx)[:cold_start]).to eq(true)
     end
   end
-  context 'with a succesful handler' do
-    subject { Datadog::Lambda.wrap(event, context) { { result: 100 } } }
-    let(:event) { '1' }
-    let(:context) { ctx }
-
-    it 'should return the same value as returned by the block' do
-      expect(subject[:result]).to be 100
-    end
-  end
   context 'with a handler that raises an error' do
     subject { Datadog::Lambda.wrap(event, context) { raise 'Error' } }
     let(:event) { '1' }
@@ -28,6 +19,20 @@ describe Datadog::Lambda do
 
     it 'should raise an error if the block raises an error' do
       expect { subject }.to raise_error
+    end
+  end
+  context 'enhanced tags' do
+    it 'recognizes an error as having warmed the environment' do
+      expect(Datadog::Lambda.gen_enhanced_tags(ctx)[:cold_start]).to eq(false)
+    end
+  end
+  context 'with a succesful handler' do
+    subject { Datadog::Lambda.wrap(event, context) { { result: 100 } } }
+    let(:event) { '1' }
+    let(:context) { ctx }
+
+    it 'should return the same value as returned by the block' do
+      expect(subject[:result]).to be 100
     end
   end
   context 'trace_context' do

--- a/test/datadog/lambda.spec.rb
+++ b/test/datadog/lambda.spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/BlockLength
-
 require 'datadog/lambda'
 require_relative './lambdacontext'
 
@@ -89,6 +88,7 @@ describe Datadog::Lambda do
       # rubocop:enable Metrics/LineLength
     end
   end
+
   context 'enhanced metrics' do
     it 'correctly reads the DD_ENHANCED_METRICS env var' do
       allow(ENV).to receive(:[]).with('DD_ENHANCED_METRICS').and_return('true')
@@ -115,6 +115,16 @@ describe Datadog::Lambda do
     it 'submits enhanced metrics if DD_ENHANCED_METRICS is true' do
       allow(ENV).to receive(:[]).with('DD_ENHANCED_METRICS').and_return('true')
       expect(Datadog::Lambda.record_enhanced('foo', ctx)).to eq(true)
+    end
+  end
+  context 'enhanced metrics output' do
+    it 'prints enhanced metrics to the logs' do
+      allow(ENV).to receive(:[]).with('DD_ENHANCED_METRICS').and_return('true')
+      # rubocop:disable Metrics/LineLength
+      expect do
+        Datadog::Lambda.record_enhanced('invocations', ctx)
+      end.to output(/"dd_lambda_layer:datadog-ruby25","functionname:hello-dog-ruby-dev-helloRuby25","region:us-east-1","account_id:172597598159","memorysize:128",/).to_stdout
+      # rubocop:enable Metrics/LineLength
     end
   end
 end

--- a/test/datadog/lambdacontext.rb
+++ b/test/datadog/lambdacontext.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # This is an example of the lambda context provided to a Ruby-runtimed lambda
+# c.f. https://docs.aws.amazon.com/lambda/latest/dg/ruby-context.html
 # Use dot-notation to access these properties
 class LambdaContext
   def function_name

--- a/test/datadog/lambdacontext.rb
+++ b/test/datadog/lambdacontext.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# This is an example of the lambda context provided to a Ruby-runtimed lambda
+# Use dot-notation to access these properties
+class LambdaContext
+  def function_name
+    'hello-dog-ruby-dev-helloRuby25'
+  end
+
+  def function_version
+    '$LATEST'
+  end
+
+  def invoked_function_arn
+    'arn:aws:lambda:us-east-1:172597598159:function:hello-dog-ruby-dev-hello'
+  end
+
+  def memory_limit_in_mb
+    128
+  end
+
+  def aws_request_id
+    'dcbfed85-c904-4367-bd54-984ca201ef47'
+  end
+
+  def log_group_name
+    '/aws/lambda/hello-dog-ruby-dev-helloRuby25'
+  end
+
+  def log_stream_name
+    '2020/01/23/[$LATEST]996801b3ee1a4ebd8ec6ede5cc360bc7'
+  end
+
+  def deadline_ms
+    1_579_818_015_751
+  end
+
+  def identity
+    ''
+  end
+
+  def client_context
+    ''
+  end
+end


### PR DESCRIPTION
### What does this PR do?

This adds the Invocations and Errors enhanced metrics to the Ruby lambda layer.

To be done:
- [x] naively include `invocations` and `errors`
- [x] Record all required tags per the architecture document
- [x] includes a check for `DD_ENHANCED_METRICS`
- [ ] ~respect `DD_FLUSH_TO_LOG` (needed?)~
- [ ] ~respect `DD_SITE` (needed?)~

### Testing Guidelines

- [x] Added rspec tests to test behavior
- [x] More rspec for testing log output
- [x] Test in the Demo environment

Log output  in the demo environment: 
```
{"e":1580150180,"m":"aws.lambda.enhanced.invocations","t":["dd_lambda_layer:datadog-ruby25","functionname:hello-dog-ruby-dev-helloRuby25","region:us-east-1","account_id:172597598159","memorysize:128","cold_start:false","runtime:Ruby 2.5.7"],"v":1}
{"e":1580150180,"m":"aws.lambda.enhanced.errors","t":["dd_lambda_layer:datadog-ruby25","functionname:hello-dog-ruby-dev-helloRuby25","region:us-east-1","account_id:172597598159","memorysize:128","cold_start:false","runtime:Ruby 2.5.7"],"v":1}
```

![image](https://user-images.githubusercontent.com/1136297/73208631-c9433e00-4114-11ea-9711-7a55c7383ee8.png)
