### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/lib/datadog/lambda/version.rb
+++ b/lib/datadog/lambda/version.rb
@@ -12,7 +12,7 @@ module Datadog
   module Lambda
     module VERSION
       MAJOR = 0
-      MINOR = 4
+      MINOR = 5
       PATCH = 0
       PRE = nil
 


### PR DESCRIPTION
### What does this PR do?

Bumps the version to 0.5.0

### Motivation

Deploying the datadog-lambda gem @v0.5.0
