### PR TITLE
Update homepage on gemspec

### DIFF
--- a/datadog-lambda.gemspec
+++ b/datadog-lambda.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     custom metrics to Datadog.
   MSG
 
-  spec.homepage = 'https://github.com/DataDog/dd-lambda-rb'
+  spec.homepage = 'https://github.com/DataDog/datadog-lambda-layer-rb'
   spec.license  = 'Apache-2.0'
 
   unless spec.respond_to?(:metadata)


### PR DESCRIPTION
The current gemspec homepage attribute links to a non existent repository, which breaks some tools that rely on that gemspec.

*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-rb/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Updates the homepage attribute of the gemspec.

### Motivation

The current link points to a non existent repository and some tools rely on that link to work (a good example is the dependabot dependency management from Github).

### Testing Guidelines

No testing done.
