### PR TITLE
Add log message when function raises NoMemoryError

### DIFF
--- a/lib/datadog/lambda.rb
+++ b/lib/datadog/lambda.rb
@@ -58,7 +58,7 @@ module Datadog
       rescue NoMemoryError => e
         # As of June 2020, AWS does not print NoMemoryError stack traces in Ruby
         # So, we print the error string to logs so it can be handled by the logs forwarder
-        puts 'from Datadog Lambda Layer: failed to allocate memory (NoMemoryError)'
+        puts 'failed to allocate memory (NoMemoryError)'
         raise e
       rescue StandardError => e
         record_enhanced('errors', context)

--- a/test/datadog/lambda.spec.rb
+++ b/test/datadog/lambda.spec.rb
@@ -30,7 +30,7 @@ describe Datadog::Lambda do
     it 'should raise a NoMemoryError error and print an error message if the block raises a NoMemoryError' do
       expect { subject }
         .to raise_error(NoMemoryError)
-        .and output(/from Datadog Lambda Layer\: failed to allocate memory \(NoMemoryError\)/).to_stdout
+        .and output(/failed to allocate memory \(NoMemoryError\)/).to_stdout
     end
   end
   context 'enhanced tags' do

--- a/test/datadog/lambda.spec.rb
+++ b/test/datadog/lambda.spec.rb
@@ -22,6 +22,17 @@ describe Datadog::Lambda do
       expect { subject }.to raise_error 'Error'
     end
   end
+  context 'with a handler that raises a NoMemoryError' do
+    subject { Datadog::Lambda.wrap(event, context) { raise NoMemoryError } }
+    let(:event) { '1' }
+    let(:context) { ctx }
+
+    it 'should raise a NoMemoryError error and print an error message if the block raises a NoMemoryError' do
+      expect { subject }
+        .to raise_error(NoMemoryError)
+        .and output(/from Datadog Lambda Layer\: failed to allocate memory \(NoMemoryError\)/).to_stdout
+    end
+  end
   context 'enhanced tags' do
     it 'recognizes an error as having warmed the environment' do
       expect(Datadog::Lambda.gen_enhanced_tags(ctx)[:cold_start]).to eq(false)


### PR DESCRIPTION
### What does this PR do?

Logs an error message when the wrapped function raises a `NoMemoryError`.

### Motivation

We want to implement an `out_of_memory` metric. This will be implemented in the Forwarder and count the errors that appear in the logs. Due to an apparent issue in the Lambda Ruby runtime, the stack trace is not printed in the event of a `NoMemoryError`. By catching and logging the error message in the Ruby layer, we ensure that the Forwarder will be able to detect and count this type of error.

### Testing Guidelines

I added unit test coverage, and will test the new layer in the Demo AWS account before merging.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
