### PR TITLE
Parse function version from function arn

### DIFF
--- a/lib/datadog/lambda/trace/listener.rb
+++ b/lib/datadog/lambda/trace/listener.rb
@@ -45,6 +45,11 @@ module Datadog
             resource_names: request_context.function_name
           }
         }
+        tokens = options[:tags][:function_arn].split(":")
+        if tokens.length() > 7
+          options[:tags][:function_arn] = tokens[0, 7].join(":")
+          options[:tags][:function_version] = tokens[7]
+        end
 
         options[:resource] = @handler_name
         options[:service] =  @function_name

--- a/lib/datadog/lambda/trace/listener.rb
+++ b/lib/datadog/lambda/trace/listener.rb
@@ -53,19 +53,19 @@ module Datadog
       private
 
       def get_option_tags(request_context:, cold_start:)
+        function_arn = request_context.invoked_function_arn.downcase
+        tk = function_arn.split(':')
+        function_arn = tk.length > 7 ? tk[0, 7].join(':') : function_arn
+        function_version = tk.length > 7 ? tk[7] : '$Latest'
         options = {
           tags: {
             cold_start: cold_start,
-            function_arn: request_context.invoked_function_arn.downcase,
+            function_arn: function_arn,
+            function_version: function_version,
             request_id: request_context.aws_request_id,
             resource_names: request_context.function_name
           }
         }
-        tokens = options[:tags][:function_arn].split(':')
-        if tokens.length > 7
-          options[:tags][:function_arn] = tokens[0, 7].join(':')
-          options[:tags][:function_version] = tokens[7]
-        end
         options
       end
     end

--- a/lib/datadog/lambda/trace/listener.rb
+++ b/lib/datadog/lambda/trace/listener.rb
@@ -56,7 +56,7 @@ module Datadog
         function_arn = request_context.invoked_function_arn.downcase
         tk = function_arn.split(':')
         function_arn = tk.length > 7 ? tk[0, 7].join(':') : function_arn
-        function_version = tk.length > 7 ? tk[7] : '$Latest'
+        function_version = tk.length > 7 ? tk[7] : '$LATEST'
         options = {
           tags: {
             cold_start: cold_start,

--- a/test/datadog/lambda.spec.rb
+++ b/test/datadog/lambda.spec.rb
@@ -78,7 +78,7 @@ describe Datadog::Lambda do
           functionname: 'ruby-test',
           memorysize: 128,
           region: 'us-east-1',
-          resource: 'ruby-test:Latest',
+          resource: 'ruby-test:1',
           runtime: include('Ruby 2.') }
       )
     end

--- a/test/datadog/lambda/trace/context.spec.rb
+++ b/test/datadog/lambda/trace/context.spec.rb
@@ -208,7 +208,7 @@ describe Datadog::Trace do
           function_arn: 'arn:aws:lambda:us-east-1:172597598159:function:hello-dog-ruby-dev-hello',
           request_id: 'dcbfed85-c904-4367-bd54-984ca201ef47',
           resource_names: 'hello-dog-ruby-dev-helloRuby25',
-          function_version: '$Latest'
+          function_version: '$LATEST'
         }
       )
     end

--- a/test/datadog/lambda/trace/context.spec.rb
+++ b/test/datadog/lambda/trace/context.spec.rb
@@ -207,7 +207,8 @@ describe Datadog::Trace do
           cold_start: false,
           function_arn: 'arn:aws:lambda:us-east-1:172597598159:function:hello-dog-ruby-dev-hello',
           request_id: 'dcbfed85-c904-4367-bd54-984ca201ef47',
-          resource_names: 'hello-dog-ruby-dev-helloRuby25'
+          resource_names: 'hello-dog-ruby-dev-helloRuby25',
+          function_version: '$Latest'
         }
       )
     end

--- a/test/datadog/lambda/trace/context.spec.rb
+++ b/test/datadog/lambda/trace/context.spec.rb
@@ -230,7 +230,7 @@ describe Datadog::Trace do
           function_arn: 'arn:aws:lambda:us-east-1:172597598159:function:ruby-test',
           request_id: 'dcbfed85-c904-4367-bd54-984ca201ef47',
           resource_names: 'ruby-test',
-          function_version: '$latest'
+          function_version: '1'
         }
       )
     end

--- a/test/datadog/lambdacontextversion.rb
+++ b/test/datadog/lambdacontextversion.rb
@@ -9,11 +9,11 @@ class LambdaContextVersion
   end
 
   def function_version
-    '$Latest'
+    1
   end
 
   def invoked_function_arn
-    'arn:aws:lambda:us-east-1:172597598159:function:ruby-test:$Latest'
+    'arn:aws:lambda:us-east-1:172597598159:function:ruby-test:1'
   end
 
   def memory_limit_in_mb


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-rb/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This changes in the PR allow for parsing of the function version from the function arn if there is one. If there is no function version, then a default value of $LATEST is set.

### Motivation

https://datadoghq.atlassian.net/browse/SLS-588

### Testing Guidelines

Manually tested using a locally built version of datadog-lambda with the required changes, and making sure the changes make it all the way to the datadog traces.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
