### PR TITLE
Update gemspec homepage url

### DIFF
--- a/datadog-lambda.gemspec
+++ b/datadog-lambda.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     custom metrics to Datadog.
   MSG
 
-  spec.homepage = 'https://github.com/DataDog/dd-lambda-rb'
+  spec.homepage = 'https://github.com/DataDog/datadog-lambda-layer-rb'
   spec.license  = 'Apache-2.0'
 
   unless spec.respond_to?(:metadata)

--- a/lib/datadog/lambda/version.rb
+++ b/lib/datadog/lambda/version.rb
@@ -12,7 +12,7 @@ module Datadog
   module Lambda
     module VERSION
       MAJOR = 0
-      MINOR = 7
+      MINOR = 8
       PATCH = 0
       PRE = nil
 


### PR DESCRIPTION
### What does this PR do?

Cherry-picks the commit from PR https://github.com/DataDog/datadog-lambda-layer-rb/pull/20 in order to run the CI pipeline on the branch and update the version. 

Thanks to @brafales for the contribution :clap:.

### Motivation

Incorrect repo URL in gemspec

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
